### PR TITLE
[52881][W2][API][BUG] Fix can not search by assigned email on Task Board

### DIFF
--- a/src/W2.Application/Tasks/TaskAppService.cs
+++ b/src/W2.Application/Tasks/TaskAppService.cs
@@ -272,7 +272,7 @@ namespace W2.Tasks
             if (!string.IsNullOrWhiteSpace(input.EmailRequest))
             {
                 string emailRequest = input.EmailRequest.Trim();
-                query = query.Where(x => x.W2User.Email.Contains(emailRequest));
+                query = query.Where(x => x.EmailTo.Any(email => email.Contains(emailRequest)));
             }
 
             if (!string.IsNullOrWhiteSpace(input.EmailAssign) && isAdmin)


### PR DESCRIPTION
## Checklist (check all applicable)

- [x] Fix can not search by assigned email on Task Board
- [x] Self Review
- [x] Self Test
- [x] Upload Evidence

## Description
- Fix can not search by assigned email on Task Board

## Evidence
- [Link](https://www.loom.com/share/10899dcc0c4b400ca18416e0371eca2a?sid=5955b3db-95ae-4cae-bfe0-feaa6d5e790b)

